### PR TITLE
fix: set correct program path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Run",
       "type": "python",
       "request": "launch",
-      "program": "${workspaceRoot}/main.py",
+      "program": "${workspaceRoot}/src/api.py",
       "console": "integratedTerminal",
       "justMyCode": true,
       "env": {


### PR DESCRIPTION
Sets the `program` path in the vscode launch config to the proper path