### PR TITLE
Use Steamship 2.17.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 termcolor~=2.3.0
-steamship==2.17.0
+steamship==2.17.5


### PR DESCRIPTION
Fixes problem in which `create_response` is missing from the web response handler

<img width="366" alt="image" src="https://github.com/steamship-core/multimodal-agent-starter/assets/63262/0967260f-2084-497c-9746-14047e64fb4d">
