### PR TITLE
Update reference projects to GPT version for better ReAct performance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 termcolor~=2.3.0
-steamship==2.17.7
+steamship==2.17.13

--- a/src/example_tools/pixar_style_tool.py
+++ b/src/example_tools/pixar_style_tool.py
@@ -1,5 +1,5 @@
 """Tool for generating images."""
-from typing import List, Union, Any
+from typing import Any, List, Union
 
 from steamship import Block, Task
 from steamship.agents.schema import AgentContext


### PR DESCRIPTION
The unpinned GPT endpoints are a moving target of behavior, causing the ReAct prompt to stop working over time. 

Pinning the default suggested model resolves this.